### PR TITLE
fix(cicd): correcting openapi linter

### DIFF
--- a/.github/workflows/ci-code-approval.yml
+++ b/.github/workflows/ci-code-approval.yml
@@ -140,6 +140,6 @@ jobs:
         uses: thollander/actions-comment-pull-request@v3
         with:
           # Full file path to the plan output
-          file-path: ${{ github.workspace }}/routes-validator-report.md
+          file-path: ${{ github.workspace }}/common-validator-report.md
           pr-number: ${{ github.event.pull_request.number }}
           create-if-not-exists: true

--- a/.github/workflows/ci-code-approval.yml
+++ b/.github/workflows/ci-code-approval.yml
@@ -128,13 +128,6 @@ jobs:
         run: |
           sudo apt-get install jq
 
-      - name: Install GUM
-        run: |
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL https://repo.charm.sh/apt/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/charm.gpg
-          echo "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list
-          sudo apt update && sudo apt install gum
-
       - name: Lint OpenAPI
         shell: bash
         run: |

--- a/.github/workflows/ci-code-approval.yml
+++ b/.github/workflows/ci-code-approval.yml
@@ -147,6 +147,6 @@ jobs:
         uses: thollander/actions-comment-pull-request@v3
         with:
           # Full file path to the plan output
-          file-path: ${{ github.workspace }}/common-validator-report.md
+          file-path: ${{ github.workspace }}/routes-validator-report.md
           pr-number: ${{ github.event.pull_request.number }}
           create-if-not-exists: true

--- a/common/common.yaml
+++ b/common/common.yaml
@@ -37,6 +37,7 @@ components:
         - title
         - detail
         - status
+        - details
         - requestId
       properties:
         title:
@@ -52,6 +53,6 @@ components:
           maximum: 599
         details:
           type: array
-        requestId:
+        request_id:
           type: string
           example: '123456'

--- a/common/common.yaml
+++ b/common/common.yaml
@@ -38,7 +38,7 @@ components:
         - detail
         - status
         - details
-        - requestId
+        - request_id
       properties:
         title:
           type: string

--- a/common/common.yaml
+++ b/common/common.yaml
@@ -15,6 +15,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/message'
+        '400':
+          description: 'Placeholder'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_message'
 components:
   schemas:
     message:
@@ -42,6 +48,8 @@ components:
         status:
           type: integer
           example: 400
+          minimum: 100
+          maximum: 599
         details:
           type: array
         requestId:

--- a/common/types.go
+++ b/common/types.go
@@ -5,11 +5,11 @@ package common
 
 // ErrorMessage defines the model for error_message.
 type ErrorMessage struct {
-	Detail    string         `json:"detail"`
-	Details   *[]interface{} `json:"details,omitempty"`
-	RequestId string         `json:"requestId"`
-	Status    int            `json:"status"`
-	Title     string         `json:"title"`
+	Detail    string        `json:"detail"`
+	Details   []interface{} `json:"details"`
+	RequestId *string       `json:"request_id,omitempty"`
+	Status    int           `json:"status"`
+	Title     string        `json:"title"`
 }
 
 // Message defines the model for message.

--- a/common/types.go
+++ b/common/types.go
@@ -7,7 +7,7 @@ package common
 type ErrorMessage struct {
 	Detail    string        `json:"detail"`
 	Details   []interface{} `json:"details"`
-	RequestId *string       `json:"request_id,omitempty"`
+	RequestId string        `json:"request_id"`
 	Status    int           `json:"status"`
 	Title     string        `json:"title"`
 }

--- a/handlers.go
+++ b/handlers.go
@@ -24,7 +24,7 @@ func NotFoundHandler() http.HandlerFunc {
 			)
 		}
 
-		details := []string{
+		details := []any{
 			fmt.Sprintf("method: %s", r.Method),
 			fmt.Sprintf("path: %s", r.URL.Path),
 		}
@@ -33,7 +33,7 @@ func NotFoundHandler() http.HandlerFunc {
 			details = append(details, fmt.Sprintf("query: %s", r.URL.RawQuery))
 		}
 
-		msg := NewHTTPError(http.StatusNotFound, errNotFound, details)
+		msg := NewHTTPError(http.StatusNotFound, errNotFound, details...)
 		MustEncode(rw, http.StatusNotFound, msg)
 	}
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -21,7 +21,7 @@ func TestNotFoundHandler(t *testing.T) {
 			w:      httptest.NewRecorder(),
 			r:      httptest.NewRequest(http.MethodGet, "/", nil),
 			status: http.StatusNotFound,
-			want:   "{\"detail\":\"not found\",\"details\":[[\"method: GET\",\"path: /\"]],\"requestId\":\"\",\"status\":404,\"title\":\"Not Found\"}\n",
+			want:   "{\"detail\":\"not found\",\"details\":[\"method: GET\",\"path: /\"],\"request_id\":\"\",\"status\":404,\"title\":\"Not Found\"}\n",
 		},
 	}
 

--- a/http_error.go
+++ b/http_error.go
@@ -42,7 +42,7 @@ func NewHTTPError(code int, err error, details ...any) *HTTPError {
 	}
 
 	if len(details) > 0 {
-		errMsg.Details = &details
+		errMsg.Details = details
 	}
 
 	return &HTTPError{

--- a/openapi-lint.sh
+++ b/openapi-lint.sh
@@ -26,7 +26,7 @@ for file in $routesFiles; do
 done
 
 # Combine all the reports into a single file. Separate each report with a horizontal rule.
-cat ./routes-validator-report-*.md >./routes-validator-report.md
+cat ./common-validator-report*.md >./routes-validator-report.md
 
 if [ "$score" -lt 100 ]; then
   echo "IBM OpenAPI Linter found issues with the OpenAPI specification. Please fix the issues and try again."

--- a/openapi-lint.sh
+++ b/openapi-lint.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-debug=false
-if [[ $1 == "--debug" ]]; then
-  debug=true
-fi
-
 # Check that the IBM OpenAPI Linter is installed
 if ! command -v lint-openapi >/dev/null; then
   gum style --foreground 196 "Error: IBM OpenAPI Linter is not installed. Please install the linter by following the instructions at https://github.com/IBM/openapi-validator"
@@ -12,132 +7,28 @@ if ! command -v lint-openapi >/dev/null; then
 fi
 
 # Find all routes.yaml files in the ./pkg/codegen/apis directory
-routesFiles=$(find ./common -name "common.yaml")
+routesFiles=$(find ./pkg/codegen/apis -name "routes.yaml")
 
-touch ./pr-report.md
-echo "## OpenAPI Linting Report" >./pr-report.md
-
-totalErrors=0
-totalWarnings=0
-totalInfos=0
-totalHints=0
+score=0
 
 # Lint each routes.yaml file
 for file in $routesFiles; do
   rm -rf ./lint-output.json
 
-  gum spin --spinner dot --title "Linting $file" -- lint-openapi -c ./openapi-lint-config.yaml -s "$file" > ./lint-output.json
+  lint-openapi -c ./openapi-lint-config.yaml -s "$file" >./lint-output.json
 
-  # Make ./pkg/codegen/apis/api/routes.yaml -> api/routes.yaml
-  prettyName=$(echo $file | sed 's/\.\/pkg\/codegen\/apis\///' | sed 's/\/routes.yaml//')
+  # Make ./pkg/codegen/apis/api/routes.yaml -> api
+  apiName=$(echo "$file" | sed -e 's/.*\/\(.*\)\/routes.yaml/\1/')
 
-  gum style --foreground 10 "Linting $prettyName"
+  mv ./routes-validator-report.md "./routes-validator-report-$apiName.md"
 
-  # Print the lint output (Only used when the --debug flag is passed)
-  if [[ $debug == true ]]; then
-    cat ./lint-output.json
-  fi
-
-  # Put the header on the PR report
-  cat <<EOF >>./pr-report.md
-### Linting $prettyName
-\`\`\`
-EOF
-
-  # Get the total number of errors, warnings, infos, and hints
-  errors=$(cat ./lint-output.json | jq .error.summary.total)
-  warnings=$(cat ./lint-output.json | jq .warning.summary.total)
-  infos=$(cat ./lint-output.json | jq .info.summary.total)
-  hints=$(cat ./lint-output.json | jq .hint.summary.total)
-
-  # Put the lint output in the PR report
-  cat <<EOF >>./pr-report.md
-$errors errors, $warnings warnings, $infos infos, $hints hints
-EOF
-
-  # Put the footer on the PR report
-  cat <<EOF >>./pr-report.md
-\`\`\`
-
-EOF
-
-  if [[ $errors -gt 0 ]]; then
-    cat <<EOF >>./pr-report.md
-#### Error Messages
-\`\`\`
-EOF
-
-    cat ./lint-output.json | jq -r '.error.summary.entries[].generalizedMessage' >>./pr-report.md
-
-    cat <<EOF >>./pr-report.md
-\`\`\`
-
-EOF
-  fi
-
-  if [[ $warnings -gt 0 ]]; then
-    cat <<EOF >>./pr-report.md
-#### Warning Messages
-\`\`\`
-EOF
-
-    cat ./lint-output.json | jq -r '.warning.summary.entries[].generalizedMessage' >>./pr-report.md
-
-    cat <<EOF >>./pr-report.md
-\`\`\`
-
-EOF
-  fi
-
-  if [[ $infos -gt 0 ]]; then
-    cat <<EOF >>./pr-report.md
-#### Info Messages
-\`\`\`
-EOF
-
-    cat ./lint-output.json | jq -r '.info.summary.entries[].generalizedMessage' >>./pr-report.md
-
-    cat <<EOF >>./pr-report.md
-\`\`\`
-
-EOF
-  fi
-
-  if [[ $hints -gt 0 ]]; then
-    cat <<EOF >>./pr-report.md
-#### Hint Messages
-\`\`\`
-EOF
-
-    cat ./lint-output.json | jq -r '.hint.summary.entries[].generalizedMessage' >>./pr-report.md
-
-    cat <<EOF >>./pr-report.md
-\`\`\`
-
-EOF
-  fi
-
-  # Add the errors, warnings, infos, and hints to the total
-  totalErrors=$((totalErrors + errors))
-  totalWarnings=$((totalWarnings + warnings))
-  totalInfos=$((totalInfos + infos))
-  totalHints=$((totalHints + hints))
+  score=$(jq '.impactScore.categorizedSummary.overall' ./lint-output.json)
 done
 
-# CLean up when the script exits if the --debug flag is passed
-if [[ $debug == true ]]; then
-  gum style --foreground 214 "Cleaning up"
-  rm -rf lint-output.json
-  rm -rf pr-report.md
-fi
+# Combine all the reports into a single file. Separate each report with a horizontal rule.
+cat ./routes-validator-report-*.md >./routes-validator-report.md
 
-if [[ $totalErrors -gt 0 ]]; then
-  gum style --foreground 196 "FAIL: Linting failed with $totalErrors errors, $totalWarnings warnings, $totalInfos infos, and $totalHints hints"
+if [ "$score" -lt 100 ]; then
+  echo "IBM OpenAPI Linter found issues with the OpenAPI specification. Please fix the issues and try again."
   exit 1
-elif [[ $totalWarnings -gt 0 ]]; then
-  gum style --foreground 214 "PASS: Linting passed with $totalErrors errors, $totalWarnings warnings, $totalInfos infos, and $totalHints hints"
-  exit 1
-else
-  gum style --foreground 10 "PASS: Linting passed with $totalErrors errors, $totalWarnings warnings, $totalInfos infos, and $totalHints hints"
-  exit 0
 fi

--- a/openapi-lint.sh
+++ b/openapi-lint.sh
@@ -25,9 +25,6 @@ for file in $routesFiles; do
   score=$(jq '.impactScore.categorizedSummary.overall' ./lint-output.json)
 done
 
-# Combine all the reports into a single file. Separate each report with a horizontal rule.
-cat ./common-validator-report.md >./routes-validator-report.md
-
 if [ "$score" -lt 100 ]; then
   echo "IBM OpenAPI Linter found issues with the OpenAPI specification. Please fix the issues and try again."
   exit 1

--- a/openapi-lint.sh
+++ b/openapi-lint.sh
@@ -8,7 +8,7 @@ fi
 
 score=0
 
-lint-openapi -c ./openapi-lint-config.yaml -s ./common/config/openapi.yaml >./lint-output.json
+lint-openapi -c ./openapi-lint-config.yaml -s ./common/common.yaml >./lint-output.json
 score=$(jq '.impactScore.categorizedSummary.overall' ./lint-output.json)
 
 if [ "$score" -lt 100 ]; then

--- a/openapi-lint.sh
+++ b/openapi-lint.sh
@@ -6,24 +6,10 @@ if ! command -v lint-openapi >/dev/null; then
   exit 1
 fi
 
-# Find all routes.yaml files in the ./pkg/codegen/apis directory
-routesFiles=$(find ./pkg/codegen/apis -name "routes.yaml")
-
 score=0
 
-# Lint each routes.yaml file
-for file in $routesFiles; do
-  rm -rf ./lint-output.json
-
-  lint-openapi -c ./openapi-lint-config.yaml -s "$file" >./lint-output.json
-
-  # Make ./pkg/codegen/apis/api/routes.yaml -> api
-  apiName=$(echo "$file" | sed -e 's/.*\/\(.*\)\/routes.yaml/\1/')
-
-  mv ./routes-validator-report.md "./routes-validator-report-$apiName.md"
-
-  score=$(jq '.impactScore.categorizedSummary.overall' ./lint-output.json)
-done
+lint-openapi -c ./openapi-lint-config.yaml -s "$file" >./lint-output.json
+score=$(jq '.impactScore.categorizedSummary.overall' ./lint-output.json)
 
 if [ "$score" -lt 100 ]; then
   echo "IBM OpenAPI Linter found issues with the OpenAPI specification. Please fix the issues and try again."

--- a/openapi-lint.sh
+++ b/openapi-lint.sh
@@ -26,7 +26,7 @@ for file in $routesFiles; do
 done
 
 # Combine all the reports into a single file. Separate each report with a horizontal rule.
-cat ./common-validator-report*.md >./routes-validator-report.md
+cat ./common-validator-report.md >./routes-validator-report.md
 
 if [ "$score" -lt 100 ]; then
   echo "IBM OpenAPI Linter found issues with the OpenAPI specification. Please fix the issues and try again."

--- a/openapi-lint.sh
+++ b/openapi-lint.sh
@@ -8,7 +8,7 @@ fi
 
 score=0
 
-lint-openapi -c ./openapi-lint-config.yaml -s "$file" >./lint-output.json
+lint-openapi -c ./openapi-lint-config.yaml -s ./common/config/openapi.yaml >./lint-output.json
 score=$(jq '.impactScore.categorizedSummary.overall' ./lint-output.json)
 
 if [ "$score" -lt 100 ]; then


### PR DESCRIPTION
This pull request includes several changes aimed at improving the OpenAPI linting process, updating workflow configurations, and enhancing the OpenAPI schema definitions. The most important changes include removing the installation of GUM, updating the file path for the OpenAPI linting report, refining the OpenAPI schema, and simplifying the `openapi-lint.sh` script.

### Workflow Configuration Updates:
* [`.github/workflows/ci-code-approval.yml`](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L131-L137): Removed the installation steps for GUM and updated the file path for the OpenAPI linting report from `common-validator-report.md` to `routes-validator-report.md`. [[1]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L131-L137) [[2]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L150-R143)

### OpenAPI Schema Enhancements:
* [`common/common.yaml`](diffhunk://#diff-3f815ffe7258f764700e107c86fa82f749fa9b7e22db708e5d89a1788ec92708R18-R23): Added a '400' error response placeholder and defined minimum and maximum values for the status code in the schema. [[1]](diffhunk://#diff-3f815ffe7258f764700e107c86fa82f749fa9b7e22db708e5d89a1788ec92708R18-R23) [[2]](diffhunk://#diff-3f815ffe7258f764700e107c86fa82f749fa9b7e22db708e5d89a1788ec92708R51-R52)

### Script Simplification:
* [`openapi-lint.sh`](diffhunk://#diff-1819c2155e17eb3447ea9828b53bf99c6447245047cbee753e3ec4a9b3afdc64L3-L142): Removed debug-related code and simplified the script by focusing on essential linting tasks and combining all individual reports into a single file. The script now checks the overall impact score to determine if the linting passes or fails.