### PR TITLE
fix(http-error): Updating http error to be nil safe on nil err provided

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -3,6 +3,8 @@ package uhttp
 const (
 	loggingKeyError = "err"
 
+	defaultHttpErrorDetail = "An error occurred"
+
 	HeaderContentType = "Content-Type"
 	HeaderRequestID   = "X-Request-ID"
 

--- a/http_error.go
+++ b/http_error.go
@@ -33,12 +33,14 @@ func (e *HTTPError) SetRequestId(requestId string) {
 // NewHTTPError creates a new HTTPError.
 func NewHTTPError(code int, err error, details ...any) *HTTPError {
 	errMsg := &common.ErrorMessage{
-		Title:  http.StatusText(code),
-		Detail: err.Error(),
-		Status: code,
-
-		// RequestId will be populated at error write time
+		Title:     http.StatusText(code),
+		Detail:    defaultHttpErrorDetail,
+		Status:    code,
 		RequestId: "",
+	}
+
+	if err != nil {
+		errMsg.Detail = err.Error()
 	}
 
 	if len(details) > 0 {

--- a/http_error.go
+++ b/http_error.go
@@ -33,9 +33,11 @@ func (e *HTTPError) SetRequestId(requestId string) {
 // NewHTTPError creates a new HTTPError.
 func NewHTTPError(code int, err error, details ...any) *HTTPError {
 	errMsg := &common.ErrorMessage{
-		Title:     http.StatusText(code),
-		Detail:    defaultHttpErrorDetail,
-		Status:    code,
+		Title:  http.StatusText(code),
+		Detail: defaultHttpErrorDetail,
+		Status: code,
+
+		// RequestId will be populated at error write time
 		RequestId: "",
 	}
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request focuses on improving error handling in the `uhttp` package by introducing a default error detail message and refining the way error details are set in the `HTTPError` struct. The most important changes include adding a default error detail constant and updating the `NewHTTPError` function to use this default value when no specific error message is provided.

Improvements to error handling:

* [`consts.go`](diffhunk://#diff-f0067949ae0f48685cd310e00ccaf0c72d02048ccc6aeb0a862cd30b81e5e566R6-R7): Added a new constant `defaultHttpErrorDetail` with the value "An error occurred" to provide a default error detail message.

Refinements to `HTTPError` struct:

* [`http_error.go`](diffhunk://#diff-7f64d57071ccac8cc85393616e32b0b76585f804634abe433850df6756234038L37-R45): Modified the `NewHTTPError` function to use `defaultHttpErrorDetail` as the default error detail. Additionally, it now checks if an error is provided and updates the error detail accordingly.