### PR TITLE
chore(linters): updating according to linters

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -10,7 +10,7 @@ import (
 
 // MustEncode encodes a response as JSON and logs an error if it fails
 func MustEncode[T any](w http.ResponseWriter, status int, v T) {
-	if err := Encode(w, status, v); err != nil {
+	if err := Encode(w, status, v); err != nil { // nolint:revive // This is traditional GO error handling
 		slog.Error("Error encoding response", slog.String(loggingKeyError, err.Error()))
 		return
 	}

--- a/response_writer.go
+++ b/response_writer.go
@@ -92,16 +92,17 @@ func (c *ResponseWriter) writeDefaultHeaders() {
 	if c.defaultHeadersWritten {
 		return
 	}
-
 	c.defaultHeadersWritten = true
 
-	if c.defaultHeaders != nil {
-		for header, value := range c.defaultHeaders {
-			if c.Header().Get(header) != "" {
-				// If the header has already been set, do not overwrite it.
-				continue
-			}
-			c.Header().Set(header, value)
+	if c.defaultHeaders == nil {
+		return
+	}
+
+	for header, value := range c.defaultHeaders {
+		if c.Header().Get(header) != "" {
+			// If the header has already been set, do not overwrite it.
+			continue
 		}
+		c.Header().Set(header, value)
 	}
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to improve error handling and ensure correct header writing in the `encoding.go` and `response_writer.go` files. The most important changes are as follows:

Error handling improvements:
* [`encoding.go`](diffhunk://#diff-4f0911c09fe38ddaea5af43243b784b66bc7408213df312455b8f916a57001a0L13-R13): Added a `nolint:revive` comment to the `MustEncode` function to suppress linting warnings and maintain traditional Go error handling.

Header writing corrections:
* [`response_writer.go`](diffhunk://#diff-0de8b54c7ec5735d514acbd89340faa9f4546859e9e0cce3862c4488e45e996bL95-R100): Modified the `writeDefaultHeaders` function to return early if `c.defaultHeaders` is `nil`, preventing unnecessary iterations and potential errors.
* [`response_writer.go`](diffhunk://#diff-0de8b54c7ec5735d514acbd89340faa9f4546859e9e0cce3862c4488e45e996bL107): Removed an extra newline for better code readability and consistency.