### PR TITLE
chore(cicd): adding additional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,15 @@ linters:
     - iface
     - thelper
     - tparallel
+    - intrange
+    - testifylint
+    - perfsprint
+issues:
+  exclude-rules:
+    - path: (.+)_test.go
+      linters:
+        - revive
+      text: "^(enforce-slice-style|enforce-map-style)"
 linters-settings:
   revive:
     # Default: false
@@ -135,3 +144,5 @@ linters-settings:
     enable:
       - identical # Identifies interfaces in the same package that have identical method sets.
       - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.
+  testifylint:
+    enable-all: true

--- a/handlers.go
+++ b/handlers.go
@@ -2,7 +2,6 @@ package uhttp
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 )
 
@@ -25,12 +24,12 @@ func NotFoundHandler() http.HandlerFunc {
 		}
 
 		details := []any{
-			fmt.Sprintf("method: %s", r.Method),
-			fmt.Sprintf("path: %s", r.URL.Path),
+			"method: " + r.Method,
+			"path: " + r.URL.Path,
 		}
 
 		if r.URL.RawQuery != "" {
-			details = append(details, fmt.Sprintf("query: %s", r.URL.RawQuery))
+			details = append(details, "query: "+r.URL.RawQuery)
 		}
 
 		msg := NewHTTPError(http.StatusNotFound, errNotFound, details...)
@@ -60,12 +59,12 @@ func MethodNotAllowedHandler() http.HandlerFunc {
 		}
 
 		details := []string{
-			fmt.Sprintf("method: %s", r.Method),
-			fmt.Sprintf("path: %s", r.URL.Path),
+			"method: " + r.Method,
+			"path: " + r.URL.Path,
 		}
 
 		if r.URL.RawQuery != "" {
-			details = append(details, fmt.Sprintf("query: %s", r.URL.RawQuery))
+			details = append(details, "query: "+r.URL.RawQuery)
 		}
 
 		msg := NewHTTPError(http.StatusMethodNotAllowed, errMethodNotAllowed, details)
@@ -95,12 +94,12 @@ func UnauthorizedHandler() http.HandlerFunc {
 		}
 
 		details := []string{
-			fmt.Sprintf("method: %s", r.Method),
-			fmt.Sprintf("path: %s", r.URL.Path),
+			"method: ", r.Method,
+			"path: ", r.URL.Path,
 		}
 
 		if r.URL.RawQuery != "" {
-			details = append(details, fmt.Sprintf("query: %s", r.URL.RawQuery))
+			details = append(details, "query: "+r.URL.RawQuery)
 		}
 
 		msg := NewHTTPError(http.StatusUnauthorized, errUnauthorized, details)

--- a/request.go
+++ b/request.go
@@ -2,8 +2,8 @@ package uhttp
 
 import (
 	"context"
-	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -79,7 +79,7 @@ func GenerateRequestIDToContext(r *http.Request) context.Context {
 func generateRequestID(r *http.Request) string {
 	str := r.Method + r.URL.Path + r.RemoteAddr
 	str += r.Header.Get("User-Agent")
-	str += fmt.Sprintf("%d", time.Now().Unix())
+	str += strconv.FormatInt(time.Now().UnixNano(), 10)
 
 	return uuid.NewSHA1(uuid.New(), []byte(str)).String()
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to improve the linters configuration and refactor the code in the `uhttp` package. The most important changes include adding new linters to the configuration, modifying the exclusion rules, and refactoring string concatenation to remove unnecessary `fmt` package usage.

### Linters Configuration:

* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R15-R23): Added `intrange`, `testifylint`, and `perfsprint` linters.
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R15-R23): Added exclusion rules for `revive` linter in test files.
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R147-R148): Enabled all rules for `testifylint`.

### Code Refactoring:

* [`handlers.go`](diffhunk://#diff-56307bdb7ded67ebe516f562b90384407b21b2d34e8b5766b42602e1fb9705f0L5): Removed `fmt` package import as it is no longer needed.
* [`handlers.go`](diffhunk://#diff-56307bdb7ded67ebe516f562b90384407b21b2d34e8b5766b42602e1fb9705f0L28-R32): Refactored string concatenation in `NotFoundHandler`, `MethodNotAllowedHandler`, and `UnauthorizedHandler` to remove `fmt.Sprintf` usage. [[1]](diffhunk://#diff-56307bdb7ded67ebe516f562b90384407b21b2d34e8b5766b42602e1fb9705f0L28-R32) [[2]](diffhunk://#diff-56307bdb7ded67ebe516f562b90384407b21b2d34e8b5766b42602e1fb9705f0L63-R67) [[3]](diffhunk://#diff-56307bdb7ded67ebe516f562b90384407b21b2d34e8b5766b42602e1fb9705f0L98-R102)
* [`request.go`](diffhunk://#diff-3c2feffcf57ffb6c596dc5608186c518252092b7017be5189d3dc12aa3c45cecL5-R6): Removed `fmt` package import and replaced `fmt.Sprintf` with `strconv.FormatInt` for generating request IDs. [[1]](diffhunk://#diff-3c2feffcf57ffb6c596dc5608186c518252092b7017be5189d3dc12aa3c45cecL5-R6) [[2]](diffhunk://#diff-3c2feffcf57ffb6c596dc5608186c518252092b7017be5189d3dc12aa3c45cecL82-R82)