### PR TITLE
feat(ratelimiter): adding rate limiter functionality

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -2,6 +2,7 @@ package uhttp
 
 const (
 	loggingKeyError = "err"
+	loggingKeyKey   = "key"
 
 	defaultHttpErrorDetail = "An error occurred"
 

--- a/rate_limiter.go
+++ b/rate_limiter.go
@@ -63,5 +63,5 @@ func (r *rateLimiter) log(level slog.Level, msg string, args ...any) {
 		return
 	}
 
-	r.l.Log(context.Background(), level, msg, args...)
+	r.l.Log(context.Background(), level, msg, args...) // nolint:sloglint // Handler around the messages passed in to prevent panics on nil logger
 }

--- a/rate_limiter.go
+++ b/rate_limiter.go
@@ -28,7 +28,7 @@ type rateLimiter struct {
 
 // NewRateLimiter creates a new rate limiter.
 func NewRateLimiter(rps float64, burst int, opts ...RateLimiterOption) RateLimiter {
-	if burst == 0 || burst < int(rps) {
+	if burst == 0 || float64(burst) < rps {
 		burst = int(rps)
 	}
 

--- a/rate_limiter_options.go
+++ b/rate_limiter_options.go
@@ -1,0 +1,12 @@
+package uhttp
+
+import "log/slog"
+
+type RateLimiterOption = func(*rateLimiter)
+
+// WithLogger sets the logger for the rate limiter.
+func WithLogger(l *slog.Logger) RateLimiterOption {
+	return func(r *rateLimiter) {
+		r.l = l
+	}
+}


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several updates to the `uhttp` package, focusing on enhancing the rate limiter functionality and improving logging capabilities. The most important changes include adding a new logging key, updating the rate limiter implementation, and introducing rate limiter options.

Improvements to logging:

* [`consts.go`](diffhunk://#diff-f0067949ae0f48685cd310e00ccaf0c72d02048ccc6aeb0a862cd30b81e5e566R5): Added a new logging key `loggingKeyKey` for enhanced log messages.

Enhancements to rate limiter:

* [`rate_limiter.go`](diffhunk://#diff-a34633b86cdcf8fb8f089ed6e7503b59da50b0657be1395087175ff056c96937L3-R20): Refactored the import statements and added new dependencies such as `context`, `slog`, and `sync`.
* [`rate_limiter.go`](diffhunk://#diff-a34633b86cdcf8fb8f089ed6e7503b59da50b0657be1395087175ff056c96937L22-R67): Updated the `rateLimiter` struct to use `sync.Map` for thread-safe access and added a logger field.
* [`rate_limiter.go`](diffhunk://#diff-a34633b86cdcf8fb8f089ed6e7503b59da50b0657be1395087175ff056c96937L22-R67): Modified the `NewRateLimiter` function to accept options and handle burst values more efficiently.
* [`rate_limiter_options.go`](diffhunk://#diff-f8faaf6fd3e5cdbf23c12aa7862159f448bad810e43a91edad37def9c2736ea7R1-R12): Introduced a new file to define rate limiter options, including a function to set a logger.