### PR TITLE
fix(ratelimiter): preventing nil err from causing error

### DIFF
--- a/redis_rate_limiter.go
+++ b/redis_rate_limiter.go
@@ -2,6 +2,7 @@ package uhttp
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -50,7 +51,7 @@ func (r *redisRateLimiter) Allow(key string) bool {
 
 	// Try to set key with value 1 and 1-second TTL if not exists
 	setReply, err := redis.String(r.keydb.DoCtx(ctx, "SET", redisKey, 1, "EX", int(r.window.Seconds()), "NX"))
-	if err != nil {
+	if err != nil && !errors.Is(err, redis.ErrNil) {
 		r.log(slog.LevelError, "failed to set rate limit key", slog.String(loggingKeyKey, redisKey), slog.String(loggingKeyError, err.Error()))
 		return false
 	} else if setReply == "OK" {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to the `redis_rate_limiter.go` file in the `uhttp` package to improve error handling and logging.

Improvements to error handling:

* [`redis_rate_limiter.go`](diffhunk://#diff-8ba5cdca06a7216420900ebac6e1e32a0556305461b1872d9f935d2a62661ebbR5): Added the `errors` package import to handle error comparison.
* [`redis_rate_limiter.go`](diffhunk://#diff-8ba5cdca06a7216420900ebac6e1e32a0556305461b1872d9f935d2a62661ebbL53-R54): Modified the `Allow` method to use `errors.Is` for checking if the error is `redis.ErrNil` to handle specific error cases more gracefully.